### PR TITLE
fixes in print-format specifiers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ add_test(camp_v1_paper_modal ${CMAKE_BINARY_DIR}/data_run/CAMP_v1_paper/modal/te
 ######################################################################
 # camp library
 
-set(STD_C_FLAGS "-std=c99")
+set(STD_C_FLAGS "-std=c99 -Werror=format")
 set(STD_CUDA_FLAGS "-dc -arch=compute_70 -code=sm_70")
 
 if(${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel")

--- a/src/rxns/rxn_surface.c
+++ b/src/rxns/rxn_surface.c
@@ -391,12 +391,12 @@ void rxn_surface_print(int *rxn_int_data, double *rxn_float_data) {
       printf("\n  - d_reactant/d_phase_species_%d Jacobian id %d",
              i_elem, PHASE_JAC_ID_(i_phase,0,i_elem));
       for (int i_prod = 0; i_prod < NUM_PROD_; ++i_prod) {
-        printf("\n  - d_product_%s/d_phase_species_%d Jacobian id %d",
+        printf("\n  - d_product_%d/d_phase_species_%d Jacobian id %d",
                i_prod, i_elem, PHASE_JAC_ID_(i_phase,i_prod+1,i_elem));
       }
-      printf("\n  - d_radius/d_phase_species_%d = %le", i_elem,
+      printf("\n  - d_radius/d_phase_species_%d = %le",
              i_elem, EFF_RAD_JAC_ELEM_(i_phase,i_elem));
-      printf("\n  - d_number/d_phase_species_%d = %le", i_elem,
+      printf("\n  - d_number/d_phase_species_%d = %le",
              i_elem, EFF_RAD_JAC_ELEM_(i_phase,i_elem));
     }
   }


### PR DESCRIPTION
Noticed in PyPartMC build logs from Github:
 
```
[ 32%] Building C object CMakeFiles/camplib.dir/gitmodules/camp/src/rxns/rxn_surface.c.o
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c: In function ‘rxn_surface_print’:
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c:394:34: warning: format ‘%s’ expects argument of type ‘char *’, but argument 2 has type ‘int’ [-Wformat=]
  394 |         printf("\n  - d_product_%s/d_phase_species_%d Jacobian id %d",
      |                                 ~^
      |                                  |
      |                                  char *
      |                                 %d
  395 |                i_prod, i_elem, PHASE_JAC_ID_(i_phase,i_prod+1,i_elem));
      |                ~~~~~~             
      |                |
      |                int
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c:397:53: warning: format ‘%le’ expects argument of type ‘double’, but argument 3 has type ‘int’ [-Wformat=]
  397 |       printf("\n  - d_radius/d_phase_species_%d = %le", i_elem,
      |                                                   ~~^
      |                                                     |
      |                                                     double
      |                                                   %d
  398 |              i_elem, EFF_RAD_JAC_ELEM_(i_phase,i_elem));
      |              ~~~~~~                                  
      |              |
      |              int
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c:397:14: warning: too many arguments for format [-Wformat-extra-args]
  397 |       printf("\n  - d_radius/d_phase_species_%d = %le", i_elem,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c:399:53: warning: format ‘%le’ expects argument of type ‘double’, but argument 3 has type ‘int’ [-Wformat=]
  399 |       printf("\n  - d_number/d_phase_species_%d = %le", i_elem,
      |                                                   ~~^
      |                                                     |
      |                                                     double
      |                                                   %d
  400 |              i_elem, EFF_RAD_JAC_ELEM_(i_phase,i_elem));
      |              ~~~~~~                                  
      |              |
      |              int
/tmp/build-via-sdist-q4x7n4hb/PyPartMC-0.9.3.post6/gitmodules/camp/src/rxns/rxn_surface.c:399:14: warning: too many arguments for format [-Wformat-extra-args]
  399 |       printf("\n  - d_number/d_phase_species_%d = %le", i_elem,
      |              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```