### PR TITLE
Species object within phase

### DIFF
--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -251,7 +251,6 @@ contains
 
     ! allocate space for the phase property set
     property_set => property_t()
-    spec_property_set => property_t()
 
     ! cycle through the phase properties to find the name and species
     ! and load the remaining data into the phase property set
@@ -315,9 +314,11 @@ contains
     print *, "num_spec: ", num_spec
     i_spec = 0
     allocate(this%spec_property_set(num_spec))
+    spec_property_set => property_t()
     next => null()
     call json%get_child(j_obj, child)
     do while (associated(child))
+      key = "species"
       call json%info(child, name=key, var_type=var_type)
 
       ! chemical species in the phase
@@ -325,15 +326,13 @@ contains
         i_spec = i_spec + 1
         call json%get_child(child, species)
         do while (associated(species))
-          call json%info(species, var_type=var_type)
+          call json%info(species, name=key, var_type=var_type)
           if (var_type.eq.json_object) then
-            call json%get(species, "name", species_name)
             ! load remaining properties into the species property set
             if (key.ne."type") then
               call spec_property_set%load(json, species, .false., this%spec_name(i_spec)%string)
-              print *, "loaded properties for:", trim(species_name)
             end if
-            this%spec_property_set(i_spec)%val_ => spec_property_set
+            this%spec_property_set(i_spec)%val_ => spec_property_set 
           else if (var_type.eq.json_string) then
             this%spec_property_set(i_spec)%val_ => spec_property_set
           end if

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -647,7 +647,6 @@ contains
 
     integer :: new_size
     type(string_t), pointer :: new_name(:)
-    real(kind=dp), pointer :: new_diff(:)
 
     if (size(this%spec_name) .ge. this%num_spec + num_spec) return
     new_size = this%num_spec + num_spec + REALLOC_INC
@@ -656,28 +655,17 @@ contains
     deallocate(this%spec_name)
     this%spec_name => new_name
 
-    if (.not. associated(this%diffusion_coeff)) then
-      allocate(this%diffusion_coeff(new_size))
-      this%diffusion_coeff(:) = -9999
-    else
-      allocate(new_diff(new_size))
-      new_diff(1:this%num_spec) = this%diffusion_coeff(1:this%num_spec)
-      deallocate(this%diffusion_coeff)
-      this%diffusion_coeff => new_diff
-    end if
-
   end subroutine ensure_size
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Add a new chemical species to the phase
-  subroutine add(this, spec_name, diff_coeff)
+  subroutine add(this, spec_name)
 
     !> Aerosol phase data
     class(aero_phase_data_t), intent(inout) :: this
     !> Name of the species to add
     character(len=*), intent(in) :: spec_name
-    real(kind=dp), intent(in), optional :: diff_coeff
 
     integer(kind=i_kind) :: i_spec
 
@@ -687,15 +675,9 @@ contains
               " added more than once to phase "//this%name())
       return
     end if
-    print *, "spec_name func", spec_name
     call this%ensure_size(1)
     this%num_spec = this%num_spec + 1
     this%spec_name(this%num_spec)%string = spec_name
-    ! Store diffusion coefficient if available
-    if (present(diff_coeff)) then
-      !allocate(this%diffusion_coeff(this%num_spec))
-      this%diffusion_coeff(this%num_spec) = diff_coeff
-    end if
 
   end subroutine add
 

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -330,7 +330,7 @@ contains
             call json%get(species, "name", species_name)
             ! load remaining properties into the species property set
             if (key.ne."type") then
-              call spec_property_set%load(json, species, .false., species_name)
+              call spec_property_set%load(json, species, .false., this%spec_name(i_spec)%string)
               print *, "loaded properties for:", trim(species_name)
             end if
             this%spec_property_set(i_spec)%val_ => spec_property_set

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -86,11 +86,11 @@ module camp_aero_phase_data
     !! camp_camp_core::camp_core_t::chem_spec_data variable during
     !! initialization.
     type(string_t), pointer :: spec_name(:) => null()
-    !!> Diffusion coefficients associated with species. When species
+    !!> Property set associated with species. When species
     !! are input in JSON files as objects, associated properties
     !! can be included (currently only diffusion coefficient but 
     !! other properties can be added).
-    real(kind=dp), pointer :: diffusion_coeff(:) => null()
+    type(property_t), pointer :: spec_prop_set(:) => null()
     !> Aerosol phase parameters. These will be available during
     !! initialization, but not during solving.
     type(property_t), pointer :: property_set => null()
@@ -274,9 +274,13 @@ contains
         do while (associated(species))
           call json%info(species, var_type=var_type)
           if (var_type.eq.json_object) then
-            ! handle species object with optional properties
+            ! handle species object
             call json%get(species, "name", species_name)
             call this%add(species_name)
+            ! load remaining properties into the species property set
+            if (key.ne."type") then
+              call property_set%load(json, child, .false., species_name)
+            end if
           else if (var_type.eq.json_string) then
             ! string species name 
             call json%get(species, unicode_str_val)

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -275,12 +275,8 @@ contains
           call json%info(species, var_type=var_type)
           if (var_type.eq.json_object) then
             ! handle species object with optional properties
-            call json%get_child(species, species_obj)
-            call json%get(species_obj, "name", species_name)
-            call json%get(species_obj, "diffusion coefficient [m2 s-1]", diff_coeff)
-            print *, "spec_name", species_name
-            print *, "diffusion coeff", diff_coeff
-            call this%add(species_name, diff_coeff)
+            call json%get(species, "name", species_name)
+            call this%add(species_name)
           else if (var_type.eq.json_string) then
             ! string species name 
             call json%get(species, unicode_str_val)

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -90,7 +90,7 @@ module camp_aero_phase_data
     !! are input in JSON files as objects, associated properties
     !! can be included (currently only diffusion coefficient but 
     !! other properties can be added).
-    type(property_t), pointer :: spec_prop_set(:) => null()
+    type(property_t), pointer :: spec_property_set => null()
     !> Aerosol phase parameters. These will be available during
     !! initialization, but not during solving.
     type(property_t), pointer :: property_set => null()
@@ -245,11 +245,12 @@ contains
     integer(kind=i_kind) :: var_type
 
     character(len=:), allocatable :: str_val
-    type(property_t), pointer :: property_set
+    type(property_t), pointer :: property_set, spec_property_set
     real(kind=dp), pointer :: diff_coeff
 
     ! allocate space for the phase property set
     property_set => property_t()
+    spec_property_set => property_t()
 
     ! cycle through the phase properties to find the name and species
     ! and load the remaining data into the phase property set
@@ -279,7 +280,7 @@ contains
             call this%add(species_name)
             ! load remaining properties into the species property set
             if (key.ne."type") then
-              call property_set%load(json, child, .false., species_name)
+              call spec_property_set%load(json, child, .false., species_name)
             end if
           else if (var_type.eq.json_string) then
             ! string species name 

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -316,6 +316,7 @@ contains
     allocate(this%spec_property_set(num_spec))
     spec_property_set => property_t()
     next => null()
+    !spec_property_set => property_t()
     call json%get_child(j_obj, child)
     do while (associated(child))
       call json%info(child, name=key, var_type=var_type)
@@ -335,15 +336,15 @@ contains
               if (key.ne."name".and.key.ne."type") then
                 call spec_property_set%load(json, species_child, .false., this%spec_name(i_spec)%string)
                 print *, "found properties for: ", this%spec_name(i_spec)%string
-                this%spec_property_set(i_spec)%val_ => spec_property_set
-              else
-                this%spec_property_set(i_spec)%val_ => spec_property_set
               end if
               call json%get_next(species_child, next)
               species_child => next
             end do 
+            this%spec_property_set(i_spec)%val_ => spec_property_set
           else if (var_type.eq.json_string) then
-              this%spec_property_set(i_spec)%val_ => spec_property_set
+            ! species given as just a string name → still give an empty set
+            !spec_property_set => property_t()
+            this%spec_property_set(i_spec)%val_ => spec_property_set     
           end if
           call json%get_next(species, next)
           species => next
@@ -671,14 +672,25 @@ contains
 
     !> Aerosol phase data
     type(aero_phase_data_t), intent(inout) :: this
+    integer(kind=i_kind) :: i
 
     if (allocated(this%phase_name))    deallocate(this%phase_name)
     if (associated(this%spec_name))    deallocate(this%spec_name)
     if (associated(this%property_set)) deallocate(this%property_set)
+    !if (associated(this%spec_property_set%val_)) deallocate(this%spec_property_set%val_)
     if (allocated(this%condensed_data_real)) &
                                        deallocate(this%condensed_data_real)
     if (allocated(this%condensed_data_int)) &
                                        deallocate(this%condensed_data_int)
+
+    if (allocated(this%spec_property_set)) then
+      do i = 1, size(this%spec_property_set)
+        if (associated(this%spec_property_set(i)%val_)) then
+          deallocate(this%spec_property_set(i)%val_)
+        end if
+      end do
+      deallocate(this%spec_property_set)
+    end if
 
   end subroutine finalize
 

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -118,6 +118,7 @@ module camp_aero_phase_data
     procedure :: num_jac_elem
     !> Get property data associated with this phase
     procedure :: get_property_set
+    !> Get property data associated with a species in a phase
     procedure :: get_spec_property_set
     !> Get a list of species names in this phase
     procedure :: get_species_names
@@ -518,9 +519,7 @@ contains
     integer(i_kind) :: i_spec   
 
     i_spec = this%find(spec_name)
-    !allocate(spec_property_set(this%spec_property_set(i_spec)%val_%size()))
     spec_property_set => this%spec_property_set(i_spec)%val_
-    !deallocate(spec_property_set)
 
   end function get_spec_property_set
 

--- a/src/aero_phase_data.F90
+++ b/src/aero_phase_data.F90
@@ -119,6 +119,7 @@ module camp_aero_phase_data
     procedure :: num_jac_elem
     !> Get property data associated with this phase
     procedure :: get_property_set
+    procedure :: get_spec_property_set
     !> Get a list of species names in this phase
     procedure :: get_species_names
     !> Get a species type by name
@@ -501,30 +502,23 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the aerosol phase species property set
-!  function get_spec_property_set(this, spec_name) result (spec_property_set)
+  function get_spec_property_set(this, spec_name) result (spec_property_set)
 
     !> A pointer to the aerosol phase property set
-!    class(property_t), pointer :: spec_property_set
+    class(property_t), pointer :: spec_property_set
     !> Species name to find properties of
-!    character(len=*), intent(in) :: spec_name
+    character(len=*), intent(in) :: spec_name
     !> Aerosol phase data
-!   class(aero_phase_data_t), intent(in) :: this
+   class(aero_phase_data_t), intent(in) :: this
 
-!    integer(i_kind) :: i_spec   
-!
-!    spec_property_set => null()
-!    i_spec = 0
-!    do i_spec = 1, this%num_spec
-!      if (this%spec_name(i_spec)%string .eq. spec_name) then
-!        if (associated(this%spec_property_set)) then
-!          if (this%spec_property_set(i_spec)%val%size() > 0) then
-!            spec_property_set => this%spec_property_set(i_spec)
-!          end if
-!        end if
-!      end if
-!    end do
-!
-!  end function get_spec_property_set
+    integer(i_kind) :: i_spec   
+
+    i_spec = this%find(spec_name)
+    !allocate(spec_property_set(this%spec_property_set(i_spec)%val_%size()))
+    spec_property_set => this%spec_property_set(i_spec)%val_
+    !deallocate(spec_property_set)
+
+  end function get_spec_property_set
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/test/unit_aero_phase_data/test_aero_phase_data.F90
+++ b/test/unit_aero_phase_data/test_aero_phase_data.F90
@@ -140,10 +140,15 @@ contains
     call assert(368026503, spec_property_set%get_real(key, temp_real))
     call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
 
-    !spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species e")
-    !call spec_property_set%print()
-    !call assert(316478321, spec_property_set%size().eq.0)
-
+    spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species e")
+    call spec_property_set%print()
+    call assert(379859264, spec_property_set%size().eq.2)
+    key = "diffusion coefficient [m2 s-1]"
+    call assert(354007455, spec_property_set%get_real(key, temp_real))
+    call assert(568601191, almost_equal(temp_real, real(2.0, kind=dp)))
+    key = "crazy mmonkey"
+    call assert(114400485, spec_property_set%get_real(key, temp_real))
+    call assert(150893490, almost_equal(temp_real, real(13.0, kind=dp)))
     !spec_property_set => aero_phase_data_set(2)%val%get_spec_property_set("species c")
     !call spec_property_set%print()
     !call assert(641586524, spec_property_set%size().eq.0)

--- a/test/unit_aero_phase_data/test_aero_phase_data.F90
+++ b/test/unit_aero_phase_data/test_aero_phase_data.F90
@@ -135,20 +135,21 @@ contains
 
     spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species b")
     key = "diffusion coefficient [m2 s-1]"
-    call spec_property_set%print()
     call assert(143255788, spec_property_set%size().eq.2)
     call assert(368026503, spec_property_set%get_real(key, temp_real))
     call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
-    key = "crazy monkey"
+    key = "species property"
     call assert(114400485, spec_property_set%get_real(key, temp_real))
     call assert(150893490, almost_equal(temp_real, real(13.0, kind=dp)))
 
     spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species e")
-    call spec_property_set%print()
-    call assert(379859264, spec_property_set%size().eq.1)
+    call assert(379859264, spec_property_set%size().eq.2)
     key = "diffusion coefficient [m2 s-1]"
     call assert(354007455, spec_property_set%get_real(key, temp_real))
     call assert(568601191, almost_equal(temp_real, real(2.0, kind=dp)))
+    key = "another species property"
+    call assert(958241656, spec_property_set%get_real(key, temp_real))
+    call assert(091832840, almost_equal(temp_real, real(13.3, kind=dp)))
 
     spec_property_set => aero_phase_data_set(2)%val%get_spec_property_set("species c")
     call spec_property_set%print()

--- a/test/unit_aero_phase_data/test_aero_phase_data.F90
+++ b/test/unit_aero_phase_data/test_aero_phase_data.F90
@@ -136,22 +136,23 @@ contains
     spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species b")
     key = "diffusion coefficient [m2 s-1]"
     call spec_property_set%print()
-    call assert(143255788, spec_property_set%size().eq.1)
+    call assert(143255788, spec_property_set%size().eq.2)
     call assert(368026503, spec_property_set%get_real(key, temp_real))
     call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
+    key = "crazy monkey"
+    call assert(114400485, spec_property_set%get_real(key, temp_real))
+    call assert(150893490, almost_equal(temp_real, real(13.0, kind=dp)))
 
     spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species e")
     call spec_property_set%print()
-    call assert(379859264, spec_property_set%size().eq.2)
+    call assert(379859264, spec_property_set%size().eq.1)
     key = "diffusion coefficient [m2 s-1]"
     call assert(354007455, spec_property_set%get_real(key, temp_real))
     call assert(568601191, almost_equal(temp_real, real(2.0, kind=dp)))
-    key = "crazy mmonkey"
-    call assert(114400485, spec_property_set%get_real(key, temp_real))
-    call assert(150893490, almost_equal(temp_real, real(13.0, kind=dp)))
-    !spec_property_set => aero_phase_data_set(2)%val%get_spec_property_set("species c")
-    !call spec_property_set%print()
-    !call assert(641586524, spec_property_set%size().eq.0)
+
+    spec_property_set => aero_phase_data_set(2)%val%get_spec_property_set("species c")
+    call spec_property_set%print()
+    call assert(641586524, spec_property_set%size().eq.0)
 
 #ifdef CAMP_USE_MPI
     pack_size = 0

--- a/test/unit_aero_phase_data/test_aero_phase_data.F90
+++ b/test/unit_aero_phase_data/test_aero_phase_data.F90
@@ -135,8 +135,18 @@ contains
 
     spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species b")
     key = "diffusion coefficient [m2 s-1]"
-    !call assert(368026503, spec_property_set%get_real(key, temp_real))
-    !call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
+    call spec_property_set%print()
+    call assert(143255788, spec_property_set%size().eq.1)
+    call assert(368026503, spec_property_set%get_real(key, temp_real))
+    call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
+
+    !spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species e")
+    !call spec_property_set%print()
+    !call assert(316478321, spec_property_set%size().eq.0)
+
+    !spec_property_set => aero_phase_data_set(2)%val%get_spec_property_set("species c")
+    !call spec_property_set%print()
+    !call assert(641586524, spec_property_set%size().eq.0)
 
 #ifdef CAMP_USE_MPI
     pack_size = 0

--- a/test/unit_aero_phase_data/test_aero_phase_data.F90
+++ b/test/unit_aero_phase_data/test_aero_phase_data.F90
@@ -64,7 +64,7 @@ contains
     type(json_value), pointer :: j_obj, j_next
 
     integer(kind=i_kind) :: i_phase, i_spec
-    type(property_t), pointer :: property_set
+    type(property_t), pointer :: property_set, spec_property_set
     character(len=:), allocatable :: key
     real(kind=dp) :: temp_real
     logical :: temp_logical
@@ -132,6 +132,11 @@ contains
     call assert(278773971, aero_phase_data_set(1)%val%size().eq.3)
     call assert(608559165, aero_phase_data_set(2)%val%size().eq.3)
     call assert(438402261, aero_phase_data_set(3)%val%size().eq.2)
+
+    spec_property_set => aero_phase_data_set(3)%val%get_spec_property_set("species b")
+    key = "diffusion coefficient [m2 s-1]"
+    !call assert(368026503, spec_property_set%get_real(key, temp_real))
+    !call assert(979338893, almost_equal(temp_real, real(1.0, kind=dp)))
 
 #ifdef CAMP_USE_MPI
     pack_size = 0

--- a/test/unit_aero_phase_data/test_aero_phase_data.json
+++ b/test/unit_aero_phase_data/test_aero_phase_data.json
@@ -21,7 +21,9 @@
                  "diffusion coefficient [m2 s-1]": 1.0
              },
              {
-                "name": "species e"
+                "name": "species e",
+                "diffusion coefficient [m2 s-1]": 2.0,
+                "crazy monkey": 13.0
              }
         ],
 	"some property" : 13.75

--- a/test/unit_aero_phase_data/test_aero_phase_data.json
+++ b/test/unit_aero_phase_data/test_aero_phase_data.json
@@ -17,7 +17,8 @@
 	"type" : "AERO_PHASE",
 	"species" : [
              {
-                 "name": "species b"
+                 "name": "species b",
+                 "diffusion coefficient [m2 s-1]": 1.0
              },
              {
                 "name": "species e"

--- a/test/unit_aero_phase_data/test_aero_phase_data.json
+++ b/test/unit_aero_phase_data/test_aero_phase_data.json
@@ -19,11 +19,12 @@
              {
                  "name": "species b",
                  "diffusion coefficient [m2 s-1]": 1.0,
-                 "crazy monkey": 13.0
+                 "species property": 13.0
              },
              {
                 "name": "species e",
-                "diffusion coefficient [m2 s-1]": 2.0
+                "diffusion coefficient [m2 s-1]": 2.0,
+                "another species property": 13.3
              }
         ],
 	"some property" : 13.75

--- a/test/unit_aero_phase_data/test_aero_phase_data.json
+++ b/test/unit_aero_phase_data/test_aero_phase_data.json
@@ -18,12 +18,12 @@
 	"species" : [
              {
                  "name": "species b",
-                 "diffusion coefficient [m2 s-1]": 1.0
+                 "diffusion coefficient [m2 s-1]": 1.0,
+                 "crazy monkey": 13.0
              },
              {
                 "name": "species e",
-                "diffusion coefficient [m2 s-1]": 2.0,
-                "crazy monkey": 13.0
+                "diffusion coefficient [m2 s-1]": 2.0
              }
         ],
 	"some property" : 13.75

--- a/test/unit_aero_phase_data/test_aero_phase_data.json
+++ b/test/unit_aero_phase_data/test_aero_phase_data.json
@@ -15,7 +15,14 @@
 {
 	"name" : "my last test phase",
 	"type" : "AERO_PHASE",
-	"species" : ["species b", "species e"],
+	"species" : [
+             {
+                 "name": "species b"
+             },
+             {
+                "name": "species e"
+             }
+        ],
 	"some property" : 13.75
 },
 {


### PR DESCRIPTION
Modified json inputs and associated source code (aero_phase_data.F90) so each species within a phase can have an associated property set (spec_property_set). This allows each species within a phase to have a condensed-phase associated "diffusion coefficient [m2 s-1]" which will be used for the diffusion rxn. The modified json input for a phase is shown below and in test/unit_aero_phase_data/test_aero_phase_data.json. 

{
        "name" : "my test phase",
        "type" : "AERO_PHASE",
        "species" : [
             {
                 "name": "species a",
                 "diffusion coefficient [m2 s-1]": 1.0,
                 "species property": 13.0
             },
             {
                "name": "species b",
                "diffusion coefficient [m2 s-1]": 2.0
             }
        ],
        "some property" : 13.75
}