### PR TITLE
Add aerosol phase data to reaction init functions

### DIFF
--- a/src/camp_core.F90
+++ b/src/camp_core.F90
@@ -710,7 +710,7 @@ contains
     ! Initialize the mechanisms
     do i_mech = 1, size(this%mechanism)
       call this%mechanism(i_mech)%val%initialize(this%chem_spec_data, &
-              this%aero_rep, this%n_cells)
+              this%aero_phase, this%aero_rep, this%n_cells)
     end do
 
     ! Allocate space for the variable types and absolute tolerances

--- a/src/mechanism_data.F90
+++ b/src/mechanism_data.F90
@@ -34,6 +34,7 @@ module camp_mechanism_data
   use mpi
 #endif
   use camp_aero_rep_data
+  use camp_aero_phase_data
   use camp_chem_spec_data
   use camp_constants,                  only : i_kind, dp
   use camp_mpi
@@ -245,12 +246,15 @@ contains
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Initialize the mechanism
-  subroutine initialize(this, chem_spec_data, aero_rep_data, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase_data, aero_rep_data, &
+      n_cells)
 
     !> Chemical mechanism
     class(mechanism_data_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase_data(:)
     !> Aerosol representation data
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep_data(:)
     !> Number of grid cells to solve simultaneously
@@ -260,8 +264,8 @@ contains
 
     do i_rxn = 1, this%num_rxn
       call assert(340397127, associated(this%rxn_ptr(i_rxn)%val))
-      call this%rxn_ptr(i_rxn)%val%initialize(chem_spec_data, aero_rep_data, &
-                                              n_cells)
+      call this%rxn_ptr(i_rxn)%val%initialize(chem_spec_data, aero_phase_data, &
+                                              aero_rep_data, n_cells)
     end do
 
   end subroutine initialize

--- a/src/rxn_data.F90
+++ b/src/rxn_data.F90
@@ -65,6 +65,7 @@ module camp_rxn_data
 #ifdef CAMP_USE_MPI
   use mpi
 #endif
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                  only : i_kind, dp
@@ -199,14 +200,17 @@ interface
   !! This routine should be called once for each reaction
   !! at the beginning of a model run after all the input files have been
   !! read in.
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
     use camp_util,                                only : i_kind
-    import :: rxn_data_t, chem_spec_data_t, aero_rep_data_ptr
+    import :: rxn_data_t, chem_spec_data_t, aero_phase_data_ptr, &
+              aero_rep_data_ptr
 
     !> Reaction data
     class(rxn_data_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_CMAQ_H2O2.F90
+++ b/src/rxns/rxn_CMAQ_H2O2.F90
@@ -69,6 +69,7 @@
 !> The rxn_CMAQ_H2O2_t type and associated functions.
 module camp_rxn_CMAQ_H2O2
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -135,12 +136,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_CMAQ_H2O2_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_CMAQ_OH_HNO3.F90
+++ b/src/rxns/rxn_CMAQ_OH_HNO3.F90
@@ -70,6 +70,7 @@
 !> The rxn_CMAQ_OH_HNO3_t type and associated functions.
 module camp_rxn_CMAQ_OH_HNO3
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -140,12 +141,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_CMAQ_OH_HNO3_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_HL_phase_transfer.F90
+++ b/src/rxns/rxn_HL_phase_transfer.F90
@@ -169,12 +169,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_HL_phase_transfer_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_SIMPOL_phase_transfer.F90
+++ b/src/rxns/rxn_SIMPOL_phase_transfer.F90
@@ -178,12 +178,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_SIMPOL_phase_transfer_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_aqueous_equilibrium.F90
+++ b/src/rxns/rxn_aqueous_equilibrium.F90
@@ -140,12 +140,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_aqueous_equilibrium_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_arrhenius.F90
+++ b/src/rxns/rxn_arrhenius.F90
@@ -65,6 +65,7 @@
 !> The rxn_arrhenius_t type and associated functions.
 module camp_rxn_arrhenius
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -130,12 +131,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_arrhenius_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells being solved simultaneously

--- a/src/rxns/rxn_condensed_phase_arrhenius.F90
+++ b/src/rxns/rxn_condensed_phase_arrhenius.F90
@@ -150,12 +150,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_condensed_phase_arrhenius_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_condensed_phase_photolysis.F90
+++ b/src/rxns/rxn_condensed_phase_photolysis.F90
@@ -185,12 +185,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_condensed_phase_photolysis_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_emission.F90
+++ b/src/rxns/rxn_emission.F90
@@ -48,6 +48,7 @@
 !> The rxn_emission_t type and associated functions.
 module camp_rxn_emission
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -163,12 +164,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_emission_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_first_order_loss.F90
+++ b/src/rxns/rxn_first_order_loss.F90
@@ -50,6 +50,7 @@
 !> The rxn_first_order_loss_t type and associated functions.
 module camp_rxn_first_order_loss
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -166,12 +167,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_first_order_loss_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_photolysis.F90
+++ b/src/rxns/rxn_photolysis.F90
@@ -60,6 +60,7 @@
 !> The rxn_photolysis_t type and associated functions.
 module camp_rxn_photolysis
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -180,12 +181,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_photolysis_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_surface.F90
+++ b/src/rxns/rxn_surface.F90
@@ -141,12 +141,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_surface_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_ternary_chemical_activation.F90
+++ b/src/rxns/rxn_ternary_chemical_activation.F90
@@ -67,6 +67,7 @@
 !> The rxn_ternary_chemical_activation_t type and associated functions.
 module camp_rxn_ternary_chemical_activation
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -136,12 +137,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_ternary_chemical_activation_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_troe.F90
+++ b/src/rxns/rxn_troe.F90
@@ -66,6 +66,7 @@
 !> The rxn_troe_t type and associated functions.
 module camp_rxn_troe
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -135,12 +136,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_troe_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/src/rxns/rxn_wennberg_no_ro2.F90
+++ b/src/rxns/rxn_wennberg_no_ro2.F90
@@ -75,6 +75,7 @@
 !> The rxn_wennberg_no_ro2_t type and associated functions.
 module camp_rxn_wennberg_no_ro2
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -140,12 +141,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_wennberg_no_ro2_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells being solved simultaneously

--- a/src/rxns/rxn_wennberg_tunneling.F90
+++ b/src/rxns/rxn_wennberg_tunneling.F90
@@ -56,6 +56,7 @@
 !> The rxn_wennberg_tunneling_t type and associated functions.
 module camp_rxn_wennberg_tunneling
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -119,12 +120,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_wennberg_tunneling_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells being solved simultaneously

--- a/src/rxns/rxn_wet_deposition.F90
+++ b/src/rxns/rxn_wet_deposition.F90
@@ -51,6 +51,7 @@
 !> The rxn_wet_deposition_t type and associated functions.
 module camp_rxn_wet_deposition
 
+  use camp_aero_phase_data
   use camp_aero_rep_data
   use camp_chem_spec_data
   use camp_constants,                        only: const
@@ -169,12 +170,14 @@ contains
   !> Initialize the reaction data, validating component data and loading
   !! any required information into the condensed data arrays for use during
   !! solving
-  subroutine initialize(this, chem_spec_data, aero_rep, n_cells)
+  subroutine initialize(this, chem_spec_data, aero_phase, aero_rep, n_cells)
 
     !> Reaction data
     class(rxn_wet_deposition_t), intent(inout) :: this
     !> Chemical species data
     type(chem_spec_data_t), intent(in) :: chem_spec_data
+    !> Aerosol phase data
+    type(aero_phase_data_ptr), intent(in) :: aero_phase(:)
     !> Aerosol representations
     type(aero_rep_data_ptr), pointer, intent(in) :: aero_rep(:)
     !> Number of grid cells to solve simultaneously

--- a/test/unit_tests/unit_test_driver.F90
+++ b/test/unit_tests/unit_test_driver.F90
@@ -69,7 +69,7 @@ program unit_test_driver
   passed = .true.
 
   ! Seed the random number generator
-  call camp_srand(0,0)
+  call camp_srand(1,0)
 
 #ifdef CAMP_USE_MPI
   ! Load the model data and initialize the cores on the primary process, then

--- a/valgrind.supp
+++ b/valgrind.supp
@@ -252,3 +252,13 @@
    fun:MPI_BCAST
    ...
 }
+{
+   <MPI_finalize>
+   Memcheck:Leak
+   match-leak-kinds: possible
+   fun:malloc
+   fun:strdup
+   ... 
+   fun:orte_finalize
+   fun:ompi_mpi_finalize
+}


### PR DESCRIPTION
This PR includes passing the aerosol phase data to reaction initialization functions, to allow reactions to access phase/species-specific data added in #36 