### PR TITLE
Function to identify species state id associated with phase id and species name

### DIFF
--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,7 +392,9 @@ interface
 
   !> Determine if specified phase(s) exist in adjacent layers. Returns array
   !! of phase_ids for adjacent phases first and second.
-  !! @ return Array of index pairs for adjacent phases
+  !! @param this Aerosol representation data
+  !! @param phase_name_first First phase name
+  !! @param phase_name_second Second phase name
 
   function adjacent_phases(this, phase_name_first, &
                            phase_name_second) result (index_pairs)
@@ -412,7 +414,9 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the species id on the state array by phase_id and species name
-  !! @return Species state id
+  !! @param this Aerosol representation data
+  !! @param phase_id Phase id
+  !! @param spec_name Species name
 
   function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
       use camp_util,                          only : i_kind, integer_to_string

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,6 +392,8 @@ interface
 
   !> Determine if specified phase(s) exist in adjacent layers. Returns array
   !! of phase_ids for adjacent phases first and second.
+  !! @param phase_name_first First phase name
+  !! @param phase_name_second Second phase name
   !! @return Array of index pairs for adjacent phases
 
   function adjacent_phases(this, phase_name_first, &
@@ -412,6 +414,8 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the species id on the state array by phase_id and species name
+  !! @param phase_id Aerosol phase id
+  !! @param spec_name Species name
   !! @return Species state id
 
   function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -121,6 +121,10 @@ module camp_aero_rep_data
     !> Get the number of Jacobian elements for calculations of mass, volume,
     !! number, etc for a particular phase
     procedure(num_jac_elem), deferred :: num_jac_elem
+    !> Determine if specified phase(s) exist in adjacent layers.
+    procedure(adjacent_phases), deferred :: adjacent_phases
+    !> Get the species id on the state array by phase_id and species name
+    procedure(spec_state_id_by_phase), deferred :: spec_state_id_by_phase
     !> Load data from an input file
     procedure :: load
     !> Get the name of the aerosol representation
@@ -383,6 +387,46 @@ interface
     integer(kind=i_kind), intent(in) :: phase_id
 
   end function num_jac_elem
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  !> Determine if specified phase(s) exist in adjacent layers. Returns array
+  !! of phase_ids for adjacent phases first and second.
+
+  function adjacent_phases(this, phase_name_first, &
+                           phase_name_second) result (index_pairs)
+    use camp_util,                                       only : i_kind
+    import :: aero_rep_data_t, index_pair_t
+
+    !> Aerosol respresentation data
+    class(aero_rep_data_t), intent(in) :: this
+    !> Function output of phase_ids for first and second phase
+    type(index_pair_t), allocatable :: index_pairs(:)
+    !> Phase names
+    character(len=*), intent(in) :: phase_name_first
+    character(len=*), intent(in) :: phase_name_second
+
+
+    end function adjacent_phases
+  
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    !> Get the species id on the state array by phase_id and species name
+
+    function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+      use camp_util,                          only : i_kind, integer_to_string
+      import :: aero_rep_data_t
+
+      !> Species state id
+      integer(kind=i_kind) :: spec_id
+      !> Aerosol representation data
+      class(aero_rep_data_t), intent(in) :: this
+      !> Phase id
+      integer(kind=i_kind), intent(in) :: phase_id
+      !> Species name
+      character(len=*), intent(in) :: spec_name
+
+    end function spec_state_id_by_phase
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -390,49 +390,49 @@ interface
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !> Determine if specified phase(s) exist in adjacent layers. Returns array
-  !! of phase_ids for adjacent phases first and second.
-  !! @param phase_name_first First phase name
-  !! @param phase_name_second Second phase name
-  !! @return Array of index pairs for adjacent phases
+   !> Determine if specified phase(s) exist in adjacent layers. Returns array
+   !! of phase_ids for adjacent phases first and second.
+   !! @param phase_name_first First phase name
+   !! @param phase_name_second Second phase name
+   !! @return Array of index pairs for adjacent phases
 
-  function adjacent_phases(this, phase_name_first, &
-                           phase_name_second) result (index_pairs)
-    use camp_util,                                       only : i_kind
-    import :: aero_rep_data_t, index_pair_t
+   function adjacent_phases(this, phase_name_first, &
+                            phase_name_second) result (index_pairs)
+     use camp_util,                                       only : i_kind
+     import :: aero_rep_data_t, index_pair_t
 
-    !> Aerosol respresentation data
-    class(aero_rep_data_t), intent(in) :: this
-    !> Function output of phase_ids for first and second phase
-    type(index_pair_t), allocatable :: index_pairs(:)
-    !> Name of first phase
-    character(len=*), intent(in) :: phase_name_first
-    !> Name of second phase
-    character(len=*), intent(in) :: phase_name_second
+     !> Function output of phase_ids for first and second phase
+     type(index_pair_t), allocatable :: index_pairs(:)
+     !> Aerosol respresentation data
+     class(aero_rep_data_t), intent(in) :: this
+     !> Name of first phase
+     character(len=*), intent(in) :: phase_name_first
+     !> Name of second phase
+     character(len=*), intent(in) :: phase_name_second
 
-    end function adjacent_phases
+   end function adjacent_phases
   
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-  !> Get the species id on the state array by phase_id and species name
-  !! @param phase_id Aerosol phase id
-  !! @param spec_name Species name
-  !! @return Species state id
+   !> Get the species id on the state array by phase_id and species name
+   !! @param phase_id Aerosol phase id
+   !! @param spec_name Species name
+   !! @return Species state id
 
-  function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
-      use camp_util,                          only : i_kind, integer_to_string
-      import :: aero_rep_data_t
+   function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+       use camp_util,                          only : i_kind, integer_to_string
+       import :: aero_rep_data_t
 
-      !> Aerosol representation data
-      class(aero_rep_data_t), intent(in) :: this
-      !> Phase id
-      integer(kind=i_kind), intent(in) :: phase_id
-      !> Species name
-      character(len=*), intent(in) :: spec_name
-      !> Species state id
-      integer(kind=i_kind) :: spec_id
+       !> Species state id
+       integer(kind=i_kind) :: spec_id
+       !> Aerosol representation data
+       class(aero_rep_data_t), intent(in) :: this
+       !> Phase id
+       integer(kind=i_kind), intent(in) :: phase_id
+       !> Species name
+       character(len=*), intent(in) :: spec_name
 
-    end function spec_state_id_by_phase
+   end function spec_state_id_by_phase
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,16 +392,12 @@ interface
 
    !> Determine if specified phase(s) exist in adjacent layers. Returns array
    !! of phase_ids for adjacent phases first and second.
-   !! @param phase_name_first First phase name
-   !! @param phase_name_second Second phase name
    !! @return Array of index pairs for adjacent phases
-
    function adjacent_phases(this, phase_name_first, &
                             phase_name_second) result (index_pairs)
      use camp_util,                                       only : i_kind
      import :: aero_rep_data_t, index_pair_t
 
-     !> Function output of phase_ids for first and second phase
      type(index_pair_t), allocatable :: index_pairs(:)
      !> Aerosol respresentation data
      class(aero_rep_data_t), intent(in) :: this
@@ -415,15 +411,11 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
    !> Get the species id on the state array by phase_id and species name
-   !! @param phase_id Aerosol phase id
-   !! @param spec_name Species name
    !! @return Species state id
-
    function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
        use camp_util,                          only : i_kind, integer_to_string
        import :: aero_rep_data_t
 
-       !> Species state id
        integer(kind=i_kind) :: spec_id
        !> Aerosol representation data
        class(aero_rep_data_t), intent(in) :: this

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,6 +392,10 @@ interface
 
   !> Determine if specified phase(s) exist in adjacent layers. Returns array
   !! of phase_ids for adjacent phases first and second.
+  !! @param this Aerosol representation data
+  !! @param phase_name_first First phase name
+  !! @param phase_name_second Second phase name
+  !! @return Array of index pairs for adjacent phases
 
   function adjacent_phases(this, phase_name_first, &
                            phase_name_second) result (index_pairs)
@@ -406,14 +410,17 @@ interface
     character(len=*), intent(in) :: phase_name_first
     character(len=*), intent(in) :: phase_name_second
 
-
     end function adjacent_phases
   
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-    !> Get the species id on the state array by phase_id and species name
+  !> Get the species id on the state array by phase_id and species name
+  !! @param this Aerosol representation data
+  !! @param phase_id Phase id
+  !! @param spec_name Species name
+  !! @return Species state id
 
-    function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+  function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
       use camp_util,                          only : i_kind, integer_to_string
       import :: aero_rep_data_t
 

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,10 +392,7 @@ interface
 
   !> Determine if specified phase(s) exist in adjacent layers. Returns array
   !! of phase_ids for adjacent phases first and second.
-  !! @param this Aerosol representation data
-  !! @param phase_name_first First phase name
-  !! @param phase_name_second Second phase name
-  !! @return Array of index pairs for adjacent phases
+  !! @ return Array of index pairs for adjacent phases
 
   function adjacent_phases(this, phase_name_first, &
                            phase_name_second) result (index_pairs)
@@ -415,9 +412,6 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the species id on the state array by phase_id and species name
-  !! @param this Aerosol representation data
-  !! @param phase_id Phase id
-  !! @param spec_name Species name
   !! @return Species state id
 
   function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -392,9 +392,7 @@ interface
 
   !> Determine if specified phase(s) exist in adjacent layers. Returns array
   !! of phase_ids for adjacent phases first and second.
-  !! @param this Aerosol representation data
-  !! @param phase_name_first First phase name
-  !! @param phase_name_second Second phase name
+  !! @return Array of index pairs for adjacent phases
 
   function adjacent_phases(this, phase_name_first, &
                            phase_name_second) result (index_pairs)
@@ -414,9 +412,7 @@ interface
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
   !> Get the species id on the state array by phase_id and species name
-  !! @param this Aerosol representation data
-  !! @param phase_id Phase id
-  !! @param spec_name Species name
+  !! @return Species state id
 
   function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
       use camp_util,                          only : i_kind, integer_to_string

--- a/src/aero_rep_data.F90
+++ b/src/aero_rep_data.F90
@@ -405,8 +405,9 @@ interface
     class(aero_rep_data_t), intent(in) :: this
     !> Function output of phase_ids for first and second phase
     type(index_pair_t), allocatable :: index_pairs(:)
-    !> Phase names
+    !> Name of first phase
     character(len=*), intent(in) :: phase_name_first
+    !> Name of second phase
     character(len=*), intent(in) :: phase_name_second
 
     end function adjacent_phases
@@ -422,14 +423,14 @@ interface
       use camp_util,                          only : i_kind, integer_to_string
       import :: aero_rep_data_t
 
-      !> Species state id
-      integer(kind=i_kind) :: spec_id
       !> Aerosol representation data
       class(aero_rep_data_t), intent(in) :: this
       !> Phase id
       integer(kind=i_kind), intent(in) :: phase_id
       !> Species name
       character(len=*), intent(in) :: spec_name
+      !> Species state id
+      integer(kind=i_kind) :: spec_id
 
     end function spec_state_id_by_phase
 

--- a/src/aero_reps/aero_rep_modal_binned_mass.F90
+++ b/src/aero_reps/aero_rep_modal_binned_mass.F90
@@ -202,6 +202,8 @@ module camp_aero_rep_modal_binned_mass
     !> Returns index_pair_t type with phase_ids of adjacent phases
     !! for modal/binned representation there are no adjacent phases
     procedure :: adjacent_phases
+    !> Get the species id for a phase and species name
+    procedure :: spec_state_id_by_phase
     !> Finalize the aerosol representation
     final :: finalize, finalize_array
 
@@ -1062,6 +1064,43 @@ contains
     allocate(index_pairs(0))
 
   end function adjacent_phases
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+!> Get the species id on the state array by phase_id and species name
+    function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+
+    !> Species state id
+    integer(kind=i_kind) :: spec_id
+    !> Aerosol representation data
+    class(aero_rep_modal_binned_mass_t), intent(in) :: this
+    !> Phase id
+    integer(kind=i_kind), intent(in) :: phase_id
+    !> Species name
+    character(len=*), intent(in) :: spec_name
+
+    type(string_t), allocatable :: spec_names(:)
+    integer(kind=i_kind) :: i_spec
+
+    call assert_msg(237861905, phase_id .ge. 1 .and. phase_id .le. size(this%phase_state_id), &
+         "Phase id out of range")
+
+    spec_names = this%aero_phase(phase_id)%val%get_species_names()
+    spec_id = 0
+    do i_spec = 1, size(spec_names)
+      if (spec_name .eq. spec_names(i_spec)%string) then
+        spec_id = this%phase_state_id(phase_id) + i_spec - 1
+        exit
+      end if
+    end do
+    deallocate(spec_names)
+
+    if (spec_id .eq. 0) then
+      call die_msg(509274806, "Cannot find species '"//trim(spec_name)//"' for phase id "// &
+                   trim(to_string(phase_id)))
+    end if
+
+  end function spec_state_id_by_phase
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/aero_reps/aero_rep_modal_binned_mass.F90
+++ b/src/aero_reps/aero_rep_modal_binned_mass.F90
@@ -1067,7 +1067,7 @@ contains
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 
-!> Get the species id on the state array by phase_id and species name
+    !> Get the species id on the state array by phase_id and species name
     function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
 
     !> Species state id

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -920,10 +920,7 @@ contains
 
       ! Determine particle number and phase index within particle
       particle_number = (phase_id - 1) / TOTAL_NUM_PHASES_ + 1
-      print *, "particle number is ", particle_number
       phase_in_particle = mod(phase_id - 1, TOTAL_NUM_PHASES_) + 1
-      print *, "phase in particle is ", phase_in_particle
-
       ! Validate particle number
       call assert_msg(918734061, particle_number .ge. 1 .and. &
                             particle_number .le. MAX_PARTICLES_, &

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -799,8 +799,8 @@ contains
     end function phase_state_size
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-
-    !> Determine is specified phase(s) exist in adjacent layers. Returns array
+    
+    !> Determine if specified phase(s) exist in adjacent layers. Returns array
     !! of phase_ids for adjacent phases first and second.
 
     function adjacent_phases(this, phase_name_first, &

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -934,7 +934,7 @@ contains
           phase_name = this%aero_phase(phase_in_particle)%val%name()
           unique_name = 'P' // trim(integer_to_string(particle_number)) // '.' // &
                         this%layer_names_(i_layer)%string // '.' // &
-                        phase_name // '.' // spec_name
+                        phase_name // '.' // trim(spec_name)
           spec_id = this%spec_state_id(unique_name)
           return
         end if

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -913,6 +913,7 @@ contains
       integer(kind=i_kind), intent(in) :: phase_id
       !> Species name
       character(len=*), intent(in) :: spec_name
+      
       integer(kind=i_kind) :: particle_number, phase_in_particle, i_layer
       character(len=:), allocatable :: unique_name, phase_name
 

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -799,7 +799,7 @@ contains
     end function phase_state_size
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-    
+
     !> Determine if specified phase(s) exist in adjacent layers. Returns array
     !! of phase_ids for adjacent phases first and second.
     function adjacent_phases(this, phase_name_first, &

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -154,6 +154,8 @@ module camp_aero_rep_single_particle
     procedure :: phase_state_size
     !> Returns index_pair_t type with phase_ids of adjacent phases
     procedure :: adjacent_phases
+    !> Get spec_state_id for a phase_id and species name
+    procedure :: spec_state_id_by_phase
     !> Finalize the aerosol representation
     final :: finalize, finalize_array
   end type aero_rep_single_particle_t
@@ -895,6 +897,59 @@ contains
       deallocate(temp_index_pairs)
 
     end function adjacent_phases
+
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+    !> Get the species id on the state array by phase_id and species name
+    function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+      !> Species state id
+      integer(kind=i_kind) :: spec_id
+      !> Aerosol representation data
+      class(aero_rep_single_particle_t), intent(in) :: this
+      !> Phase id
+      integer(kind=i_kind), intent(in) :: phase_id
+      !> Species name
+      character(len=*), intent(in) :: spec_name
+      integer(kind=i_kind) :: particle_number, phase_in_particle, i_layer
+      character(len=:), allocatable :: unique_name, phase_name
+
+      ! Validate phase_id
+      call assert_msg(782814629, phase_id .ge. 1 .and. &
+                            phase_id .le. size(this%aero_phase), &
+                            "Phase id out of range")
+
+      ! Determine particle number and phase index within particle
+      particle_number = (phase_id - 1) / TOTAL_NUM_PHASES_ + 1
+      print *, "particle number is ", particle_number
+      phase_in_particle = mod(phase_id - 1, TOTAL_NUM_PHASES_) + 1
+      print *, "phase in particle is ", phase_in_particle
+
+      ! Validate particle number
+      call assert_msg(918734061, particle_number .ge. 1 .and. &
+                            particle_number .le. MAX_PARTICLES_, &
+                      "Invalid particle number from phase_id")
+
+      ! Find which layer contains this phase
+      do i_layer = 1, NUM_LAYERS_
+        if (phase_in_particle .ge. LAYER_PHASE_START_(i_layer) .and. &
+           phase_in_particle .le. LAYER_PHASE_END_(i_layer)) then
+          ! Found the layer
+          phase_name = this%aero_phase(phase_in_particle)%val%name()
+          print *, "phase name is ", phase_name
+          unique_name = 'P' // trim(integer_to_string(particle_number)) // '.' // &
+                        this%layer_names_(i_layer)%string // '.' // &
+                        phase_name // '.' // spec_name
+          spec_id = this%spec_state_id(unique_name)
+          print *, "spec_id is ", spec_id
+          return
+        end if
+      end do
+
+      ! Should not reach here
+      call die_msg(649201846, "Could not find layer for phase id "// &
+                  trim(integer_to_string(phase_id)))
+
+    end function spec_state_id_by_phase
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -932,12 +932,10 @@ contains
            phase_in_particle .le. LAYER_PHASE_END_(i_layer)) then
           ! Found the layer
           phase_name = this%aero_phase(phase_in_particle)%val%name()
-          print *, "phase name is ", phase_name
           unique_name = 'P' // trim(integer_to_string(particle_number)) // '.' // &
                         this%layer_names_(i_layer)%string // '.' // &
                         phase_name // '.' // spec_name
           spec_id = this%spec_state_id(unique_name)
-          print *, "spec_id is ", spec_id
           return
         end if
       end do

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -802,7 +802,6 @@ contains
     
     !> Determine if specified phase(s) exist in adjacent layers. Returns array
     !! of phase_ids for adjacent phases first and second.
-
     function adjacent_phases(this, phase_name_first, &
                              phase_name_second) result(index_pairs)
 

--- a/src/aero_reps/aero_rep_single_particle.F90
+++ b/src/aero_reps/aero_rep_single_particle.F90
@@ -902,6 +902,9 @@ contains
 
     !> Get the species id on the state array by phase_id and species name
     function spec_state_id_by_phase(this, phase_id, spec_name) result(spec_id)
+
+      use camp_util, only : integer_to_string
+      
       !> Species state id
       integer(kind=i_kind) :: spec_id
       !> Aerosol representation data

--- a/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
@@ -149,7 +149,7 @@ contains
         ! Check the spec_state_id_by_phase function
         spec_name = "species a"
         spec_id = aero_rep%spec_state_id_by_phase(1, spec_name)
-        call assert(237861905, spec_id .gt. 0)
+        call assert(237861905, spec_id .eq. 1)
 
       class default
         call die_msg(570113680, rep_name)

--- a/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
@@ -120,7 +120,7 @@ contains
     type(aero_rep_factory_t) :: aero_rep_factory
     type(aero_rep_data_ptr), allocatable :: aero_rep_passed_data_set(:)
     character, allocatable :: buffer(:)
-    integer(kind=i_kind) :: pos, pack_size, i_prop, i_rep, spec_id
+    integer(kind=i_kind) :: pos, pack_size, i_prop, i_rep
 #endif
 
     build_aero_rep_data_set_test = .true.

--- a/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_modal_binned_mass.F90
@@ -120,7 +120,7 @@ contains
     type(aero_rep_factory_t) :: aero_rep_factory
     type(aero_rep_data_ptr), allocatable :: aero_rep_passed_data_set(:)
     character, allocatable :: buffer(:)
-    integer(kind=i_kind) :: pos, pack_size, i_prop, i_rep
+    integer(kind=i_kind) :: pos, pack_size, i_prop, i_rep, spec_id
 #endif
 
     build_aero_rep_data_set_test = .true.
@@ -145,6 +145,11 @@ contains
         phase_name_second = "my test phase two"
         adjacent_phases = aero_rep%adjacent_phases(phase_name_first,phase_name_second)
         call assert(919038338, size(adjacent_phases) .eq. 0)
+
+        ! Check the spec_state_id_by_phase function
+        spec_name = "species a"
+        spec_id = aero_rep%spec_state_id_by_phase(1, spec_name)
+        call assert(237861905, spec_id .gt. 0)
 
       class default
         call die_msg(570113680, rep_name)

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
@@ -287,7 +287,6 @@ contains
 
         ! test the corresponding spec_id function for a phase and species name
         spec_id = aero_rep%spec_state_id_by_phase(13, "sugar")
-        print *, "spec_id for phase 13 is ", spec_id
         call assert(224332386, spec_id .eq. 35)
         
         phase_name_first = "jam"

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
@@ -160,6 +160,7 @@ contains
     integer :: i_name, num_bread, max_part, bread_phase_instance
     integer :: num_jam, jam_phase_instance
     type(index_pair_t), allocatable :: adjacent_phases(:)
+    integer :: spec_id
     character(len=:), allocatable :: phase_name_first, phase_name_second
     integer, dimension(3) :: bread_phase_id, jam_phase_id
     integer, allocatable :: jam_phase_id_correct(:), bread_phase_id_correct(:)
@@ -283,6 +284,10 @@ contains
         call assert(987654321, adjacent_phases(12)%second_ .eq. 20)
         call assert(123456789, 12 .eq. size(adjacent_phases))
         deallocate(adjacent_phases)
+
+        ! test the corresponding spec_id function for a phase and species name
+        spec_id = aero_rep%spec_state_id_by_phase(1, "wheat")
+        call assert(224332386, spec_id .eq. 1)
         
         phase_name_first = "jam"
         phase_name_second = "almond butter"

--- a/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
+++ b/test/unit_aero_rep_data/test_aero_rep_single_particle.F90
@@ -286,8 +286,9 @@ contains
         deallocate(adjacent_phases)
 
         ! test the corresponding spec_id function for a phase and species name
-        spec_id = aero_rep%spec_state_id_by_phase(1, "wheat")
-        call assert(224332386, spec_id .eq. 1)
+        spec_id = aero_rep%spec_state_id_by_phase(13, "sugar")
+        print *, "spec_id for phase 13 is ", spec_id
+        call assert(224332386, spec_id .eq. 35)
         
         phase_name_first = "jam"
         phase_name_second = "almond butter"


### PR DESCRIPTION
Added function to `aero_reps` with inputs of `phase_id` and `spec_name` and output of unique `spec_state_id`. This will be used in `rxn_condensed_phase_diffusion` to construct the C preprocessor arrays of unique `spec_state_id`'s associated with each adjacent layer `phase_id`'s.  